### PR TITLE
add perferred_source option

### DIFF
--- a/TrailerTech.py
+++ b/TrailerTech.py
@@ -79,8 +79,12 @@ class TrailerTech():
                 if self.tmdb.get_movie_details(folder.tmdb, folder.imdb, folder.title, folder.year):
                     links.extend(self.tmdb.getLinks())
 
-        # sort links we have based on height values
+        # sort by source; reverse=True = prefer youtube-dl
+        links.sort(reverse=config.perferred_source == 'youtube', key=lambda link: link['source'])
+
+        # sort by height; reverse=True = prefer higher definition
         links.sort(reverse=True, key=lambda link: link['height'])
+
 
         log.debug('Found {} trailer Links for "{}" ({}).'.format(len(links), folder.title, folder.year))
 

--- a/settings.ini.example
+++ b/settings.ini.example
@@ -6,6 +6,7 @@ log_to_file=false
 api_key=
 
 [TRAILERS]
+preferred_source=apple
 min_resolution=480
 max_resolution=1080
 languages=en

--- a/utils/config.py
+++ b/utils/config.py
@@ -87,3 +87,10 @@ class Config(object):
             if 'APPLE' in self._raw_config.sections():
                 return self._raw_config['APPLE'].getboolean('enabled', True)
         return True
+
+    @property
+    def perferred_source(self):
+        if not self._raw_config is None:
+            if 'TRAILERS' in self._raw_config.sections():
+                return self._raw_config['TRAILERS'].get('perferred_source', 'apple').lower()
+        return 'apple'


### PR DESCRIPTION
This adds the option `perferred_source` to the settings file under `[TRAILERS]` section.  It defaults to "apple".  Solves #33  and #32 